### PR TITLE
Ajout du badge semantic release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+
 # ❔ `opt-logging`
 
 Cette librairie contient les 2 fichiers de configuration de [logback](http://logback.qos.ch/) préconisés pour


### PR DESCRIPTION
Notifier que ce projet implémente les releases sémantiques..et donne donc immédiatement l'information aux utilisateurs sur comment ils peuvent maintenir leur soft en conséquence, en particulier les montées de versions qui devront idéalement être effectuées en continu.

@mbarre @Morteum @3079rod